### PR TITLE
chore: Updated title in login component from 'Githupmun' to 'Gitmon'

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -22,7 +22,7 @@ function LoginContent() {
                 <path fillRule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clipRule="evenodd" />
               </svg>
             </div>
-            <CardTitle className="text-2xl font-bold">GitHubMon</CardTitle>
+            <CardTitle className="text-2xl font-bold">GitMon</CardTitle>
             <p className="text-muted-foreground text-sm">
               GitHub organization analytics and monitoring
             </p>
@@ -32,13 +32,13 @@ function LoginContent() {
             {error && (
               <div className="p-3 rounded-md bg-destructive/10 border border-destructive/20">
                 <p className="text-sm text-destructive">
-                  {error === 'authentication_failed' 
-                    ? 'Authentication failed. Please try again.' 
+                  {error === 'authentication_failed'
+                    ? 'Authentication failed. Please try again.'
                     : 'An error occurred during sign in. Please try again.'}
                 </p>
               </div>
             )}
-            
+
             <div className="text-center space-y-2">
               <h3 className="text-lg font-semibold">Welcome Back</h3>
               <p className="text-sm text-muted-foreground">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated the login header branding from “GitHubMon” to “GitMon” for clearer, consistent product naming.
  - Tweaked spacing around the error notice in the login view for slightly cleaner presentation.

- Refactor
  - Simplified internal error-rendering logic while preserving identical messages and behavior.
  - No changes to the login page’s public interface; existing flows and error handling remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->